### PR TITLE
feat: change ready-to-transfer output to CSV

### DIFF
--- a/commands/ready-for-transfer.js
+++ b/commands/ready-for-transfer.js
@@ -3,11 +3,12 @@ import { formatEther } from 'ethers'
 
 export const readyForTransfer = async opts => {
   const { contract } = await createContract(opts)
+  console.log('address,fil_amount')
   for (let i = 0; ; i++) {
     try {
       const address = await contract.readyForTransfer(i)
       const amount = await contract.rewardsScheduledFor(address)
-      console.log(`${address} FIL ${formatEther(amount)}`)
+      console.log(`${address},${formatEther(amount)}`)
     } catch (err) {
       break
     }


### PR DESCRIPTION
Make it easier to import the output to our spreadsheet (see the [Runbook](https://www.notion.so/spacemeridian/Runbook-How-to-Trigger-Spark-Payouts-81157006ac754fe1a07609b3392d09fb)).
